### PR TITLE
changes for lucene 4.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,8 @@
   </parent>
 
   <properties>
-    <elasticsearch.version>0.90.1</elasticsearch.version>
-    <lucene.version>4.3.0</lucene.version>
+    <elasticsearch.version>1.3.4</elasticsearch.version>
+    <lucene.version>4.9.0</lucene.version>
   </properties>
 
   <repositories>

--- a/src/main/java/org/apache/lucene/analysis/kr/KoreanAnalyzer.java
+++ b/src/main/java/org/apache/lucene/analysis/kr/KoreanAnalyzer.java
@@ -85,14 +85,14 @@ public class KoreanAnalyzer extends StopwordAnalyzerBase {
 				"이","그","저","것","수","등","들","및","에서","그리고","그래서","또","또는"}
 		);
 		
-	    CharArraySet stopSet = new CharArraySet(Version.LUCENE_42, stopWords.size(), false);
+	    CharArraySet stopSet = new CharArraySet(Version.LUCENE_4_9, stopWords.size(), false);
 	 
 	    stopSet.addAll(stopWords);
 	    STOP_WORDS_SET = CharArraySet.unmodifiableSet(stopSet);
 	}
 	  
 	public KoreanAnalyzer() {
-	    this(Version.LUCENE_42, STOP_WORDS_SET);
+	    this(Version.LUCENE_4_9, STOP_WORDS_SET);
 	}
 
 	/**
@@ -100,7 +100,7 @@ public class KoreanAnalyzer extends StopwordAnalyzerBase {
 	 * @param search
 	 */
 	public KoreanAnalyzer(boolean exactMatch) {
-	    this(Version.LUCENE_42, STOP_WORDS_SET);	    
+	    this(Version.LUCENE_4_9, STOP_WORDS_SET);
 	    this.exactMatch = exactMatch;
 	}
 	
@@ -141,7 +141,7 @@ public class KoreanAnalyzer extends StopwordAnalyzerBase {
 	*/
 	public KoreanAnalyzer(Version matchVersion, CharArraySet stopWords) {
 		super(matchVersion, stopWords); 
-	    replaceInvalidAcronym = matchVersion.onOrAfter(Version.LUCENE_42);	   
+	    replaceInvalidAcronym = matchVersion.onOrAfter(Version.LUCENE_4_9);
 	}
 	
 	

--- a/src/main/java/org/apache/lucene/analysis/kr/KoreanTokenizer.java
+++ b/src/main/java/org/apache/lucene/analysis/kr/KoreanTokenizer.java
@@ -26,6 +26,7 @@ import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
 import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
 import org.apache.lucene.analysis.tokenattributes.TypeAttribute;
+import org.apache.lucene.util.AttributeFactory;
 import org.apache.lucene.util.AttributeSource;
 import org.apache.lucene.util.Version;
 
@@ -84,16 +85,6 @@ public class KoreanTokenizer extends Tokenizer {
 	}
 
 	/**
-	 * Creates a new StandardTokenizer with a given {@link AttributeSource}.
-	 */
-	public KoreanTokenizer(Version matchVersion, AttributeSource source,
-			Reader input) {
-		super(source.getAttributeFactory(), input);
-		this.scanner = new KoreanTokenizerImpl(input);
-		init(input, matchVersion);
-	}
-
-	/**
 	 * Creates a new StandardTokenizer with a given
 	 * {@link org.apache.lucene.util.AttributeSource.AttributeFactory}
 	 */
@@ -105,7 +96,7 @@ public class KoreanTokenizer extends Tokenizer {
 	}
 
 	private final void init(Reader input, Version matchVersion) {
-		if (matchVersion.onOrAfter(Version.LUCENE_30)) {
+		if (matchVersion.onOrAfter(Version.LUCENE_4_9)) {
 			replaceInvalidAcronym = true;
 		} else {
 			replaceInvalidAcronym = false;
@@ -162,6 +153,7 @@ public class KoreanTokenizer extends Tokenizer {
 
 	@Override
 	public void reset() throws IOException {
+        super.reset();
 		scanner.yyreset(input);
 	}
 

--- a/src/main/java/org/apache/solr/analysis/kr/KoreanFilterFactory.java
+++ b/src/main/java/org/apache/solr/analysis/kr/KoreanFilterFactory.java
@@ -1,5 +1,6 @@
 package org.apache.solr.analysis.kr;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.lucene.analysis.TokenStream;
@@ -15,15 +16,18 @@ public class KoreanFilterFactory extends TokenFilterFactory {
 	private boolean hasOrigin = true;
 	
 	private boolean hasCNoun = true;
-	
-	private boolean exactMatch = false;
-	
+
+    private boolean exactMatch = false;
+
+    public KoreanFilterFactory() {
+        super(new HashMap<String, String>());
+    }
+
 	public void init(Map<String, String> args) {
-	    super.init(args);
-	    bigrammable = getBoolean("bigrammable", true);
-	    hasOrigin = getBoolean("hasOrigin", true);
-	    exactMatch = getBoolean("exactMatch", false);
-	    hasCNoun = getBoolean("hasCNoun", true);
+	    bigrammable = getBoolean(args, "bigrammable", true);
+	    hasOrigin = getBoolean(args, "hasOrigin", true);
+	    exactMatch = getBoolean(args, "exactMatch", false);
+	    hasCNoun = getBoolean(args, "hasCNoun", true);
 	}
 	  
 	public TokenStream create(TokenStream tokenstream) {

--- a/src/main/java/org/apache/solr/analysis/kr/KoreanTokenizerFactory.java
+++ b/src/main/java/org/apache/solr/analysis/kr/KoreanTokenizerFactory.java
@@ -1,27 +1,37 @@
 package org.apache.solr.analysis.kr;
 
 import java.io.Reader;
+import java.util.HashMap;
+import java.util.Map;
 
 
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.kr.KoreanTokenizer;
 import org.apache.lucene.analysis.util.TokenizerFactory;
+import org.apache.lucene.util.AttributeFactory;
+import org.apache.lucene.util.AttributeSource;
 import org.apache.lucene.util.Version;
 
 public class KoreanTokenizerFactory extends TokenizerFactory {
 
-	private Version version;
-	
-	public KoreanTokenizerFactory() {
-		version = Version.LUCENE_42;
-	}
-	
-	public KoreanTokenizerFactory(Version v) {
-		version = v;
-	}
-	
-	public Tokenizer create(Reader input) {
-		return new KoreanTokenizer(version, input);
-	}
+    private Version version;
 
+    public KoreanTokenizerFactory() {
+        super(new HashMap<String, String>());
+        version = Version.LUCENE_4_9;
+    }
+
+    public KoreanTokenizerFactory(Version v) {
+        super(new HashMap<String, String>());
+        version = v;
+    }
+
+    protected KoreanTokenizerFactory(Map<String, String> args) {
+        super(args);
+    }
+
+    @Override
+    public Tokenizer create(AttributeFactory attributeFactory, Reader reader) {
+        return new KoreanTokenizer(version, attributeFactory, reader);
+    }
 }


### PR DESCRIPTION
These changes make the analyzer compatible with Lucene 4.9, so it can run on ElasticSearch 1.3.X
